### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ quote = "1.0.7"
 proc-macro2 = "1.0.18"
 syn = "1.0.33"
 heck = "0.3.1"
-serde = "1.0.114"
+serde = { version = "1.0.114", features = ["derive"] }
 serde_yaml = "0.8.13"
-serde_derive = "1.0.114"
 itertools = "0.9.0"
 encoding_rs = "0.8.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ encoding_rs = "0.8.23"
 [dev-dependencies]
 nom = "4.1.1"
 tuple_utils = "0.3.0"
-byteorder = "1.2.7"
+byteorder = "1.3.4"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.9.0"
 encoding_rs = "0.8.23"
 
 [dev-dependencies]
-nom = "4.1.1"
+nom = "4.2.3"
 tuple_utils = "0.3.0"
 byteorder = "1.3.4"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ proc-macro = true
 
 [dependencies]
 failure = "0.1.8"
-quote = "0.6.10"
-proc-macro2 = "0.4.24"
-syn = "0.15.21"
+quote = "1.0.7"
+proc-macro2 = "1.0.18"
+syn = "1.0.33"
 heck = "0.3.1"
 serde = "1.0.114"
 serde_yaml = "0.8.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ heck = "0.3.1"
 serde = "1.0.114"
 serde_yaml = "0.8.13"
 serde_derive = "1.0.114"
-itertools = "0.7.11"
+itertools = "0.9.0"
 encoding_rs = "0.8.23"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ repository = "https://github.com/manuels/taikai"
 proc-macro = true
 
 [dependencies]
-failure = "0.1.3"
+failure = "0.1.8"
 quote = "0.6.10"
 proc-macro2 = "0.4.24"
 syn = "0.15.21"
-heck = "0.3.0"
-serde = "1.0.80"
-serde_yaml = "0.8.7"
-serde_derive = "1.0.80"
+heck = "0.3.1"
+serde = "1.0.114"
+serde_yaml = "0.8.13"
+serde_derive = "1.0.114"
 itertools = "0.7.11"
-encoding_rs = "0.8.13"
+encoding_rs = "0.8.23"
 
 [dev-dependencies]
 nom = "4.1.1"
 tuple_utils = "0.3.0"
 byteorder = "1.2.7"
-log = "0.4.6"
+log = "0.4.8"

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::type_spec::TypeSpec;
 use crate::types::Type;

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -237,7 +237,7 @@ impl Attribute {
             match typ {
                 Type::Custom(_) => {
                     quote! (
-                        flat_map!(take!(#len), #read_compound)
+                        flat_map!(take!(#len), #read_compound)// FIXME: `len` expands to `self.len`, which cause borrow of self in nom 5.x
                     )
                 }
                 _ => read_compound
@@ -268,7 +268,7 @@ impl Attribute {
             self.typ.len() == p.len() + 2 &&
             (self.typ.ends_with("le") || self.typ.ends_with("be"))
         };
-    
+
         let write_scalar = match typ {
             Type::Primitive(_) if self.typ == "u8" && self.size.is_some() => {
                 quote!(
@@ -278,7 +278,7 @@ impl Attribute {
             Type::Primitive(_) if PRIMITIVES.iter().any(primitive_with_endian) => {
                 // primitive with endian (e.g. u8be)
                 let (styp, endian) = &self.typ.split_at(self.typ.len() - 2);
-    
+
                 let endian = match *endian {
                     "le" => quote!(byteorder::LittleEndian),
                     "be" => quote!(byteorder::BigEndian),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use heck::CamelCase;
 
@@ -87,7 +88,7 @@ impl PartialEq for Enum {
         let other_scope = format!("{:?}", other.scope);
 
         self.id == other.id && self_scope == other_scope
-    } 
+    }
 }
 
 impl Eq for Enum {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "1024"]
 #![allow(dead_code)]
-#![feature(bind_by_move_pattern_guards)]
-#![feature(custom_attribute)]
 #![feature(proc_macro_span)]
 #![feature(try_blocks)]
 //#![feature(trace_macros)] trace_macros!(true);
@@ -97,7 +95,7 @@ pub fn taikai_from_file(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         let mut f = std::fs::File::open(path).context("Error opening yaml file")?;
         let mut yaml = String::new();
         f.read_to_string(&mut yaml).context("Error reading yaml file")?;
-        
+
         let code = quote!( taikai_from_str2!(#scope, #yaml); );
         code.into()
     };
@@ -131,10 +129,10 @@ pub fn taikai_from_str2(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         let precursor_impls = typ.impl_precursor_reads(&[], &None, &meta);
         let final_read = typ.impl_final_read(&[], &None);
         let final_write = typ.impl_final_write(&[], &None, &meta);
-        
+
         let code = quote!(
             #runtime
-            
+
             #context
             #definition
 
@@ -154,7 +152,7 @@ pub fn taikai_from_str2(input: proc_macro::TokenStream) -> proc_macro::TokenStre
                 }
             }
         );
-        
+
         //println!("{}", code);
 
         code.into()
@@ -184,7 +182,7 @@ pub fn test_simple(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     subtypes.insert("bar".into(), subtyp);
 
     let seq = vec![
-        Attribute::new("i", "u8", Repeat::NoRepeat, None, vec![], None, None, None), 
+        Attribute::new("i", "u8", Repeat::NoRepeat, None, vec![], None, None, None),
         Attribute::new("baz", "bar", Repeat::NoRepeat, None, vec![], None, None, None),
         Attribute::new("j", "u8", Repeat::NoRepeat, None, vec![], None, None, None)
     ];
@@ -202,10 +200,10 @@ pub fn test_simple(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let root = typ.absolute_final_path();
     let precursor_impls = typ.impl_precursor_reads(&[], &None, &meta);
     let final_impl = typ.impl_final_read(&[], &None);
-    
+
     let code = quote!(
         #runtime
-        
+
         #definition
 
         #(#precursor_impls)*
@@ -218,7 +216,7 @@ pub fn test_simple(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
         }
     );
-    
+
     //println!("{}", code);
 
     code.into()
@@ -292,10 +290,10 @@ pub fn test_resolve(_input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     let root = typ.absolute_final_path();
     let precursor_impls = typ.impl_precursor_reads(&[], &None, &meta);
     let final_impl = typ.impl_final_read(&[], &None);
-    
+
     let code = quote!(
         #runtime
-        
+
         #definition
 
         #(#precursor_impls)*
@@ -308,7 +306,7 @@ pub fn test_resolve(_input: proc_macro::TokenStream) -> proc_macro::TokenStream 
             }
         }
     );
-    
+
     //println!("{}", code);
 
     code.into()
@@ -336,8 +334,8 @@ pub fn test_compound(_input: proc_macro::TokenStream) -> proc_macro::TokenStream
     subtypes.insert("bar".into(), subtyp);
 
     let seq = vec![
-        Attribute::new("i", "u16be", Repeat::NoRepeat, None, vec![], None, None, None), 
-        Attribute::new("j", "u16le", Repeat::NoRepeat, None, vec![], None, None, None), 
+        Attribute::new("i", "u16be", Repeat::NoRepeat, None, vec![], None, None, None),
+        Attribute::new("j", "u16le", Repeat::NoRepeat, None, vec![], None, None, None),
         Attribute::new("baz", "bar", Repeat::NoRepeat, Some(quote!(self.i == 0x0102)), vec![], None, None, None),
         Attribute::new("k", "u8le", Repeat::Expr(quote!(1)), Some(quote!(self.i == 0x9999)), vec![], None, None, None),
         Attribute::new("l", "u8le", Repeat::NoRepeat, Some(quote!(true)), vec![], None, None, None),
@@ -357,10 +355,10 @@ pub fn test_compound(_input: proc_macro::TokenStream) -> proc_macro::TokenStream
     let root = typ.absolute_final_path();
     let precursor_impls = typ.impl_precursor_reads(&[], &None, &meta);
     let final_impl = typ.impl_final_read(&[], &None);
-    
+
     let code = quote!(
         #runtime
-        
+
         #definition
 
         #(#precursor_impls)*
@@ -373,7 +371,7 @@ pub fn test_compound(_input: proc_macro::TokenStream) -> proc_macro::TokenStream
             }
         }
     );
-    
+
     //println!("{}", code);
 
     code.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,6 @@ extern crate heck;
 #[macro_use] extern crate failure;
 extern crate itertools;
 
-extern crate serde;
-#[macro_use] extern crate serde_derive;
-extern crate serde_yaml;
-
 mod types;
 mod type_spec;
 mod attribute;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,6 @@
 #![feature(try_blocks)]
 //#![feature(trace_macros)] trace_macros!(true);
 
-#[macro_use] extern crate quote;
-extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use] extern crate syn;
-extern crate heck;
-
-#[macro_use] extern crate failure;
-extern crate itertools;
-
 mod types;
 mod type_spec;
 mod attribute;
@@ -23,10 +14,13 @@ mod enums;
 
 use std::rc::Rc;
 
+use syn::Token;
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 
-use failure::ResultExt;
+use failure::{ResultExt, format_err};
+
+use quote::quote;
 
 use crate::attribute::Repeat;
 use crate::attribute::Attribute;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 
 use proc_macro2::TokenStream;
 use serde::Deserialize;
+use quote::quote;
 
 use crate::types;
 use crate::enums;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use proc_macro2::TokenStream;
+use serde::Deserialize;
 
 use crate::types;
 use crate::enums;
@@ -10,7 +11,7 @@ use crate::type_spec::TypeSpec;
 use crate::attribute;
 
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "kebab-case")] 
+#[serde(rename_all = "kebab-case")]
 struct Meta {
     id: Option<String>,
     endian: Endian,
@@ -35,7 +36,7 @@ enum Endian {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "lowercase")] 
+#[serde(rename_all = "lowercase")]
 enum Repeat {
     Expr,
     Until,
@@ -61,10 +62,10 @@ struct TypeDef {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "kebab-case")] 
+#[serde(rename_all = "kebab-case")]
 struct Attribute {
     id: Option<String>,
-    #[serde(rename = "type")] 
+    #[serde(rename = "type")]
     typ: Option<String>,
 
     #[serde(skip)]
@@ -78,14 +79,14 @@ struct Attribute {
     repeat: Option<Repeat>,
     repeat_expr: Option<String>,
     repeat_until: Option<String>,
-    
-    #[serde(rename = "if")] 
+
+    #[serde(rename = "if")]
     cond: Option<String>,
-    #[serde(default)] 
+    #[serde(default)]
     contents: Vec<u8>,
 
     size: Option<String>,
-    #[serde(default)] 
+    #[serde(default)]
     size_eos: bool,
     process: Option<String>,
 
@@ -93,7 +94,7 @@ struct Attribute {
 
     terminator: Option<u8>,
     consume: Option<bool>,
-    #[serde(default)] 
+    #[serde(default)]
     include: bool,
     eos_error: Option<bool>,
 }
@@ -203,7 +204,7 @@ fn parse_attribute(id: Option<String>, a: Attribute) -> attribute::Attribute {
             attribute::Repeat::Until(expr)
         },
     };
-    
+
     let enc = a.encoding.map(|enc| {
         if encoding_rs::Encoding::for_label_no_replacement(enc.as_bytes()).is_some() {
             types::Encoding::Fixed(enc.as_bytes().to_vec())

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::type_spec::TypeSpec;
 use crate::types::Meta;
@@ -52,7 +53,7 @@ impl TypeSpec {
         let mut reads = vec![];
         let mut previous_attributes = vec![];
 
-        let iter = vec![self.absolute_first_precursor_path()].into_iter();        
+        let iter = vec![self.absolute_first_precursor_path()].into_iter();
         let precursors1 = iter.chain(self.seq.iter().map(|a| self.absolute_precursor_path(&a.id)).rev().skip(1).rev());
         let precursors2 = self.seq.iter().map(|a| self.absolute_precursor_path(&a.id));
 

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 
 use heck::CamelCase;
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::types::Type;
 

--- a/src/type_spec.rs
+++ b/src/type_spec.rs
@@ -30,7 +30,7 @@ impl PartialEq for TypeSpec {
         let other_scope = format!("{:?}", other.scope);
 
         self.id == other.id && self_scope == other_scope
-    } 
+    }
 }
 
 impl Eq for TypeSpec {}
@@ -182,7 +182,7 @@ impl TypeSpec {
     pub fn final_struct(&self) -> TokenStream {
         let name = self.name();
         let attr = self.seq.iter().map(|a| a.name());
-        
+
         let resolve_type = |a: &Attribute| -> TokenStream {
             a.absolute_path_of_compound_type(self)
         };
@@ -306,7 +306,7 @@ impl TypeSpec {
             }
 
             pub mod __subtypes {
-                #(#subtypes)*
+                #subtypes
             }
         )
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::type_spec::TypeSpec;
 
@@ -140,7 +141,7 @@ impl PartialEq for Type {
             },
             _ => false
         }
-    } 
+    }
 }
 
 impl Eq for Type {}

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 
 use itertools::Itertools;
+use quote::quote;
 
 use crate::type_spec::TypeSpec;
 use crate::types::Meta;


### PR DESCRIPTION
- Update versions of all dependencies, so it is easier to bring project up
- Get rid of `extern crate`, because in 2018 edition it is not required and not recommended
- Use serde `derive` feature instead of `serde_derive` dependency

I try to upgrade `nom` to latest version, but after upgrading I get errors from rustc about moving borrowed data. I found, that this is because of generating code like
```rust
impl __precursors::RootLen {
    #[inline]
    pub fn read______none<'a>(
        self,
        _input: &'a [u8],
        _parents: &(),
        _root: &(),
        _meta: &Meta,
        _ctx: &Context,
    ) -> IoResult<'a, __precursors::RootHelloya> {
        let _new_root = &self;
        let _new_parents = _parents.prepend(&self);
        let len = &self.len;
        match do_parse!(
            _input,
            __v: flat_map!(
                take!(self.len - 1),// <<< self is borrowed as _new_root. If replace that with `len`, it compiles
                many0!(complete!(apply!(
                    __subtypes::Sub::read___crate__test_size_eos____precursors__rootlen___crate__test_size_eos____precursors__rootlen,
                    &_new_parents,
                    _new_root,
                    _meta,
                    _ctx
                )))
            ) >> (__v)
        ) {
            Ok((_input, helloya)) => {
                debug!("{} = {:#?}", "helloya", helloya) ;
                Ok((_input, __precursors::RootHelloya { len: self.len, helloya }))
            }
            Err(err) => { warn!("Failed to read {}", "helloya") ; Err(err) }
        }
    }
}
```
but I do not yet understand how to fix it.